### PR TITLE
Update Mazda CX-9 generations: Correct first generation start year

### DIFF
--- a/generations.yaml
+++ b/generations.yaml
@@ -3,7 +3,7 @@ references:
 
 generations:
   - name: "First Generation (TB)"
-    start_year: 2007
+    start_year: 2006
     end_year: 2015
     description: "The first-generation Mazda CX-9 was introduced as Mazda's flagship three-row crossover SUV, based on the Ford CD3 platform shared with the Ford Edge but significantly modified for its larger dimensions. The exterior featured sleek styling with a prominent front grille, arched fenders, and a gently sloping roofline that gave it a more dynamic appearance than many competitors. Powered by a 3.5L V6 engine initially producing 263 horsepower (upgraded to a 3.7L V6 with 273 horsepower in 2008), paired with a six-speed automatic transmission and available in front-wheel or all-wheel drive configurations. The interior offered three-row seating for up to seven passengers with surprising second-row space and a third row usable for adults on shorter trips. Available luxury features included leather seating, three-zone automatic climate control, Bose audio system, and a power liftgate. A significant refresh in 2010 brought updated exterior styling with Mazda's five-point grille, improved interior materials, and additional technology features. Despite its size, the CX-9 maintained Mazda's reputation for engaging driving dynamics with more responsive handling than typical three-row SUVs of the era. Safety features expanded throughout its production, eventually including blind spot monitoring, rear cross-traffic alert, and forward collision warning. This generation established the CX-9 as a stylish, driver-oriented alternative in the three-row crossover segment, balancing family practicality with a more engaging driving experience than many competitors."
 


### PR DESCRIPTION
- Changed First Generation (TB) start_year from 2007 to 2006
- Wikipedia confirms CX-9 was launched at the 2006 New York International Auto Show
- Verified against https://en.wikipedia.org/wiki/Mazda_CX-9
